### PR TITLE
Add chip info to VCF output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/docker/setup_container.py
+++ b/docker/setup_container.py
@@ -4,4 +4,7 @@ r = Resources()
 
 r.get_assembly_mapping_data("NCBI36", "GRCh37")
 r.get_assembly_mapping_data("GRCh37", "GRCh38")
+r.get_gsa_resources()
+r.get_chip_clusters()
+r.get_low_quality_snps()
 r.get_reference_sequences(assembly="GRCh38")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,11 +8,11 @@ build==1.2.1
     # via pip-tools
 click==8.1.7
     # via pip-tools
-coverage[toml]==7.6.0
+coverage[toml]==7.6.1
     # via pytest-cov
 iniconfig==2.0.0
     # via pytest
-mypy==1.11.0
+mypy==1.11.2
     # via -r requirements-dev.in
 mypy-extensions==1.0.0
     # via mypy
@@ -28,15 +28,15 @@ pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
-pytest==8.2.2
+pytest==8.3.2
     # via pytest-cov
 pytest-cov==5.0.0
     # via -r requirements-dev.in
-ruff==0.5.3
+ruff==0.6.2
     # via -r requirements-dev.in
 typing-extensions==4.12.2
     # via mypy
-wheel==0.43.0
+wheel==0.44.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 atomicwrites==1.4.1
     # via snps
-numpy==2.0.0
+numpy==2.1.0
     # via
     #   pandas
     #   snps
@@ -18,7 +18,7 @@ pytz==2024.1
     # via pandas
 six==1.16.0
     # via python-dateutil
-snps==2.8.2
+snps==2.9.0
     # via -r requirements.in
 tzdata==2024.1
     # via pandas

--- a/snps2vcf/__init__.py
+++ b/snps2vcf/__init__.py
@@ -24,6 +24,11 @@ class Converter:
         if s.build == 36:
             s.remap(37)
 
+        # attempt to get chip information for Build 36 and 37 files
+        if s.build == 37:
+            s.compute_cluster_overlap()
+            s.identify_low_quality_snps()
+
         if s.build == 37:
             s.remap(38)
 
@@ -32,7 +37,12 @@ class Converter:
         os.close(fd)
 
         # write VCF to temp file
-        s.to_vcf(tmp_path, chrom_prefix="chr")
+        if s._cluster_overlap_computed and s._cluster:
+            s.to_vcf(
+                tmp_path, chrom_prefix="chr", qc_filter=True
+            )  # chip cluster exists, so include chip info
+        else:
+            s.to_vcf(tmp_path, chrom_prefix="chr")
 
         # output temp file as binary
         with open(tmp_path, "rb") as f:


### PR DESCRIPTION
* Add resources to image
* Update to incorporate `snps` [2.9.0](https://github.com/apriha/snps/releases/tag/v2.9.0)
* Include chip info in VCF output, if available